### PR TITLE
[Pending] startFeeExit spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,8 @@ plasma_mvp_files:=operator-spec.k \
               submitBlock-failure-spec.k \
               deposit-success-spec.k \
               deposit-failure-spec.k \
+			  startFeeExit-success-spec.k \
+			  startFeeExit-failure-spec.k \
               getChildChain-spec.k \
               getDepositBlock-spec.k \
               getExit-spec.k

--- a/plasma-mvp/plasma-mvp-spec.ini
+++ b/plasma-mvp/plasma-mvp-spec.ini
@@ -216,7 +216,7 @@ storage:
 +requires:
     andBool #rangeAddress(OPERATOR)
     andBool #rangeUInt(256, AMOUNT)
-    andBool #rangeAddress(256, EXITSQUEUES_TOKEN_ID)
+    andBool #rangeAddress(EXITSQUEUES_TOKEN_ID)
     andBool (OPERATOR =/=Int CALLER_ID
     orBool (notBool 0 <Int AMOUNT)
     orBool EXITSQUEUES_TOKEN_ID ==Int 0

--- a/plasma-mvp/plasma-mvp-spec.ini
+++ b/plasma-mvp/plasma-mvp-spec.ini
@@ -167,6 +167,7 @@ storage:
 +requires:
     andBool 1000 <=Int CURRENTDEPOSITBLOCK andBool CURRENTDEPOSITBLOCK <Int (2 ^Int 256)
 
+// TODO: call PriorityQueue contract
 [startFeeExit]
 output: _ => _
 callData: #abiCallData("startFeeExit", #address(TOKEN_ID), #uint256(AMOUNT))
@@ -177,7 +178,6 @@ balance: _
 requires:
     andBool #rangeAddress(TOKEN_ID)
 
- // FIXME: This spec fails.
 [startFeeExit-success]
 k: #execute => #halt
 statusCode: _ => EVMC_SUCCESS

--- a/plasma-mvp/plasma-mvp-spec.ini
+++ b/plasma-mvp/plasma-mvp-spec.ini
@@ -185,14 +185,14 @@ log: _:List ( .List => ListItem(#abiEventLog(ACCT_ID, "ExitStarted", #address(CA
 storage:
     #hashedLocation({COMPILER}, {_OPERATOR}, .IntList)           |-> OPERATOR
     #hashedLocation({COMPILER}, {_EXITSQUEUES}, TOKEN_ID)        |-> EXITSQUEUES_TOKEN_ID
-    #hashedLocation({COMPILER}, {_CURRENTFEEEXIT}, .IntList)     |-> (CURRENTFEEEXIT => CURRENTFEEEXIT +Int 1)
+    #hashedLocation({COMPILER}, {_CURRENTFEEEXIT}, .IntList)     |-> (CURRENTFEEEXIT => CURRENTFEEEXIT +Int 1) // currentFeeExit = currentFeeExit.add(1)
     0 +Word #hashedLocation({COMPILER}, {_EXITS}, CURRENTFEEEXIT) |-> (_ => CALLER_ID)
     1 +Word #hashedLocation({COMPILER}, {_EXITS}, CURRENTFEEEXIT) |-> (_ => TOKEN_ID)
     2 +Word #hashedLocation({COMPILER}, {_EXITS}, CURRENTFEEEXIT) |-> (_ => AMOUNT)
     _:Map
 +requires:
     andBool #rangeAddress(OPERATOR)
-    andBool OPERATOR ==Int CALLER_ID
+    andBool OPERATOR ==Int CALLER_ID // onlyOperator
     andBool 0 <Int EXITSQUEUES_TOKEN_ID andBool EXITSQUEUES_TOKEN_ID <Int (2 ^Int 160) // require(exitsQueues[_token] != address(0))
     andBool 0 <Int AMOUNT andBool AMOUNT <Int (2 ^Int 256) // require(_amount > 0)
 

--- a/plasma-mvp/plasma-mvp-spec.ini
+++ b/plasma-mvp/plasma-mvp-spec.ini
@@ -167,6 +167,61 @@ storage:
 +requires:
     andBool 1000 <=Int CURRENTDEPOSITBLOCK andBool CURRENTDEPOSITBLOCK <Int (2 ^Int 256)
 
+[startFeeExit]
+output: _ => _
+callData: #abiCallData("startFeeExit", #address(TOKEN_ID), #uint256(AMOUNT))
+gas: {GASCAP} => _
+callValue: 0
+refund: _ => _
+balance: _
+requires:
+    andBool #rangeAddress(TOKEN_ID)
+
+ // FIXME: This spec fails.
+[startFeeExit-success]
+k: #execute => #halt
+statusCode: _ => EVMC_SUCCESS
+log: _:List ( .List => ListItem(#abiEventLog(ACCT_ID, "ExitStarted", #address(CALLER_ID), #uint256(CURRENTFEEEXIT), #address(TOKEN_ID), #uint256(AMOUNT))) )
+storage:
+    #hashedLocation({COMPILER}, {_OPERATOR}, .IntList)           |-> OPERATOR
+    #hashedLocation({COMPILER}, {_EXITSQUEUES}, TOKEN_ID)        |-> EXITSQUEUES_TOKEN_ID
+    #hashedLocation({COMPILER}, {_CURRENTFEEEXIT}, .IntList)     |-> (CURRENTFEEEXIT => CURRENTFEEEXIT +Int 1)
+    0 +Word #hashedLocation({COMPILER}, {_EXITS}, CURRENTFEEEXIT) |-> (_ => CALLER_ID)
+    1 +Word #hashedLocation({COMPILER}, {_EXITS}, CURRENTFEEEXIT) |-> (_ => TOKEN_ID)
+    2 +Word #hashedLocation({COMPILER}, {_EXITS}, CURRENTFEEEXIT) |-> (_ => AMOUNT)
+    _:Map
++requires:
+    andBool #rangeAddress(OPERATOR)
+    andBool OPERATOR ==Int CALLER_ID
+    andBool 0 <Int EXITSQUEUES_TOKEN_ID andBool EXITSQUEUES_TOKEN_ID <Int (2 ^Int 160) // require(exitsQueues[_token] != address(0))
+    andBool 0 <Int AMOUNT andBool AMOUNT <Int (2 ^Int 256) // require(_amount > 0)
+
+    andBool #rangeUInt(256, TIME_STAMP +Int 1209601) // _created_at + 2 weeks (block.timestamp + 1 + 2 weeks)
+    andBool #rangeUInt(256, TIME_STAMP +Int 604800) // block.timestamp + 1 weeks
+    andBool #rangeUInt(256, (TIME_STAMP +Int 1209601) ^Int 128 ) // exitable_at << 128
+    andBool #rangeUInt(256, (TIME_STAMP +Int 1209601) ^Int 128 |Int CURRENTFEEEXIT) // exitable_at << 128 | _utxoPos
+
+    andBool 0 ==Int EXITS_UTXOPOS_AMOUNT // require(exits[_utxoPos].amount == 0)
+    andBool 0 <Int CURRENTFEEEXIT andBool CURRENTFEEEXIT +Int 1 <Int (2 ^Int 256) // currentFeeExit.add(1)
+
+
+[startFeeExit-failure]
+k: #execute => #halt
+statusCode: _ => EVMC_REVERT
+log: _
+storage:
+    #hashedLocation({COMPILER}, {_OPERATOR}, .IntList)       |-> OPERATOR
+    #hashedLocation({COMPILER}, {_EXITSQUEUES}, TOKEN_ID)    |-> EXITSQUEUES_TOKEN_ID
+    _:Map
++requires:
+    andBool #rangeAddress(OPERATOR)
+    andBool #rangeUInt(256, AMOUNT)
+    andBool #rangeUInt(256, EXITSQUEUES_TOKEN_ID)
+    andBool (OPERATOR =/=Int CALLER_ID
+    orBool (notBool 0 <Int AMOUNT)
+    orBool EXITSQUEUES_TOKEN_ID ==Int 0
+    )
+
 [getChildChain]
 k: #execute => #halt
 statusCode: _ => EVMC_SUCCESS

--- a/plasma-mvp/plasma-mvp-spec.ini
+++ b/plasma-mvp/plasma-mvp-spec.ini
@@ -216,7 +216,7 @@ storage:
 +requires:
     andBool #rangeAddress(OPERATOR)
     andBool #rangeUInt(256, AMOUNT)
-    andBool #rangeUInt(256, EXITSQUEUES_TOKEN_ID)
+    andBool #rangeAddress(256, EXITSQUEUES_TOKEN_ID)
     andBool (OPERATOR =/=Int CALLER_ID
     orBool (notBool 0 <Int AMOUNT)
     orBool EXITSQUEUES_TOKEN_ID ==Int 0


### PR DESCRIPTION
spec of this are lacking 
```
        addExitToQueue(currentFeeExit, msg.sender, _token, _amount, block.timestamp + 1);
        currentFeeExit = currentFeeExit.add(1);
```

Restart this after #19 (including contract call) succeeded.